### PR TITLE
[Improvement] Split MetaData module type

### DIFF
--- a/paimon-web-ui-new/src/api/models/catalog/index.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/index.ts
@@ -16,10 +16,10 @@ specific language governing permissions and limitations
 under the License. */
 
 import httpRequest from '@/api/request'
-import type { Catalog, Database, Table, TableQuery } from './interface'
+import type { Catalog, Database, Table, TableQuery } from './types'
 import type { ResponseOptions } from '@/api/types'
 
-export * from './interface'
+export * from './types'
 
 // #region catalog-controller
 

--- a/paimon-web-ui-new/src/api/models/catalog/types/catalog.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/types/catalog.ts
@@ -1,0 +1,27 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+export interface Catalog {
+  id: number;
+  createTime: string;
+  updateTime?: string;
+  catalogType: string;
+  catalogName: string;
+  warehouse: string;
+  hiveUri?: string;
+  hiveConfDir?: string;
+}

--- a/paimon-web-ui-new/src/api/models/catalog/types/database.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/types/database.ts
@@ -1,0 +1,23 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+export interface Database {
+  name: string;
+  catalogId: number;
+  catalogName: string;
+  description?: string;
+}

--- a/paimon-web-ui-new/src/api/models/catalog/types/datafile.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/types/datafile.ts
@@ -1,0 +1,39 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+export interface Datafile {
+  bucket: number;
+  filePath: string;
+  fileFormat: string;
+  schemaId: string;
+  level: number;
+  recordCount: string;
+  fileSizeInBytes: string;
+
+  // TODO: JSON String
+  partition: string;
+  minKey: string;
+  maxKey: string;
+  nullValueCounts: string;
+  minValueStats: string;
+  maxValueStats: string;
+  
+  minSequenceNumber: string;
+  maxSequenceNumber: string;
+  creationTime: string;
+}
+

--- a/paimon-web-ui-new/src/api/models/catalog/types/index.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/types/index.ts
@@ -1,0 +1,24 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+export * from './catalog'
+export * from './database'
+export * from './table'
+export * from './schema'
+export * from './snapshot'
+export * from './manifest'
+export * from './datafile'

--- a/paimon-web-ui-new/src/api/models/catalog/types/manifest.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/types/manifest.ts
@@ -15,32 +15,10 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License. */
 
-export interface Catalog {
-  id: number;
-  createTime: string;
-  updateTime?: string;
-  catalogType: string;
-  catalogName: string;
-  warehouse: string;
-  hiveUri?: string;
-  hiveConfDir?: string;
-}
-
-export interface Database {
-  name: string;
-  catalogId: number;
-  catalogName: string;
-  description?: string;
-}
-
-export interface Table {
-  catalogId: number;
-  catalogName: string;
-  databaseName: string;
-  name?: string;
-}
-
-export interface TableQuery {
-  catalogId: number;
-  databaseName: string;
+export interface Manifest {
+  fileName: string;
+  fileSize: string;
+  numAddedFiles: string;
+  numDeletedFiles: string;
+  schemaId: string;
 }

--- a/paimon-web-ui-new/src/api/models/catalog/types/schema.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/types/schema.ts
@@ -1,0 +1,38 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+export interface Schema {
+  schemaId: string;
+  fields: SchemaField[];
+  partitionKeys: string;
+  primaryKeys: string;
+  comment: string;
+  option: SchemaOption[];
+  updateTime: string;
+}
+
+export interface SchemaField {
+  id: number;
+  name: string;
+  type: string;
+  comment?: string;
+}
+
+export interface SchemaOption {
+  key: string;
+  value: string;
+}

--- a/paimon-web-ui-new/src/api/models/catalog/types/snapshot.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/types/snapshot.ts
@@ -1,0 +1,34 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+export interface Snapshot {
+  snapshotId: string;
+  schemaId: string;
+  commitUser: string;
+  commitIdentifier: string;
+  commitKind: string;
+  commitTime: string;
+  baseManifestList: string;
+  deltaManifestList: string;
+  changelogManifestList: string;
+  totalRecordCount: string;
+  deltaRecordCount: string;
+  changelogRecordCount: string;
+  addedFileCount: number;
+  deletedFileCount: number;
+  watermark: string;
+}

--- a/paimon-web-ui-new/src/api/models/catalog/types/table.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/types/table.ts
@@ -1,0 +1,28 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+export interface Table {
+  catalogId: number;
+  catalogName: string;
+  databaseName: string;
+  name?: string;
+}
+
+export interface TableQuery {
+  catalogId: number;
+  databaseName: string;
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Split MetaData module type. Predefined of schema, manifest, datafile, snapshot type.

<!-- What is the purpose of the change, or the associated issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
