### PR TITLE
[Bugfix] Fix rendering 0 of showing side

### DIFF
--- a/paimon-web-ui-new/src/layouts/content/index.tsx
+++ b/paimon-web-ui-new/src/layouts/content/index.tsx
@@ -49,11 +49,11 @@ export default defineComponent({
             <NavBar headerMenuOptions={this.menuOptions}></NavBar>
           </n-layout-header>
           <n-layout has-sider position='absolute' style='top: 64px'>
-            {this.isShowSided && (
+            {this.isShowSided ? (
               <SideBar
                 sideMenuOptions={this.sideMenuOptions}
               />
-            )}
+            ):<></>}
             <n-layout-content content-style="height: calc(100vh - 64px);">
               <router-view />
             </n-layout-content>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fixed a bug with front-end rendering 0

<img width="53" alt="image" src="https://github.com/apache/incubator-paimon-webui/assets/35210666/5fe7f24b-1db2-406a-be89-820b414a9b83">


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
