### PR TITLE
[Feature] Add list columns interface

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/TableController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/TableController.java
@@ -27,6 +27,7 @@ import org.apache.paimon.web.server.service.TableService;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -73,6 +74,22 @@ public class TableController {
     @PostMapping("/column/add")
     public R<Void> addColumn(@RequestBody TableDTO tableDTO) {
         return tableService.addColumn(tableDTO);
+    }
+
+    /**
+     * Fetches column details for a specified table.
+     *
+     * @param catalogName the catalog name
+     * @param databaseName the database name
+     * @param tableName the table name
+     * @return column details wrapped in a response object
+     */
+    @GetMapping("/column/list")
+    public R<TableVO> listColumns(
+            @RequestParam String catalogName,
+            @RequestParam String databaseName,
+            @RequestParam String tableName) {
+        return R.succeed(tableService.listColumns(catalogName, databaseName, tableName));
     }
 
     /**

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/TableController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/TableController.java
@@ -77,12 +77,12 @@ public class TableController {
     }
 
     /**
-     * Fetches column details for a specified table.
+     *  Lists columns given a table.
      *
-     * @param catalogName the catalog name
-     * @param databaseName the database name
-     * @param tableName the table name
-     * @return column details wrapped in a response object
+     * @param catalogName The name of the catalog.
+     * @param databaseName The name of the database.
+     * @param tableName The name of the table.
+     * @return Response object containing {@link TableVO} representing the table.
      */
     @GetMapping("/column/list")
     public R<TableVO> listColumns(

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/vo/TableVO.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/vo/TableVO.java
@@ -18,12 +18,18 @@
 
 package org.apache.paimon.web.server.data.vo;
 
+import org.apache.paimon.web.server.data.model.TableColumn;
+
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 /** VO of table. */
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class TableVO {
@@ -35,4 +41,8 @@ public class TableVO {
     private String databaseName;
 
     private String name;
+
+    private List<TableColumn> columns;
+
+    private List<String> partitionKey;
 }

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/TableService.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/TableService.java
@@ -132,4 +132,15 @@ public interface TableService {
      * @return Response object containing a list of {@link TableVO} representing the tables.
      */
     List<TableVO> listTables(TableDTO tableDTO);
+
+    /**
+     * Retrieves the column details of a specific table within the specified catalog and database.
+     *
+     * @param catalogName The name of the catalog where the table is located.
+     * @param databaseName The name of the database where the table is located.
+     * @param tableName The name of the table whose columns are to be retrieved.
+     * @return A {@link TableVO} object containing the details of the columns of the specified
+     *     table.
+     */
+    TableVO listColumns(String catalogName, String databaseName, String tableName);
 }

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/TableControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/TableControllerTest.java
@@ -325,4 +325,25 @@ public class TableControllerTest extends ControllerTestBase {
         R<Void> r = ObjectMapperUtils.fromJSON(responseString, new TypeReference<R<Void>>() {});
         assertEquals(200, r.getCode());
     }
+
+    @Test
+    public void testListColumns() throws Exception {
+        String responseString =
+                mockMvc.perform(
+                                MockMvcRequestBuilders.get(tablePath + "/column/list")
+                                        .cookie(cookie)
+                                        .param("catalogName", catalogName)
+                                        .param("databaseName", databaseName)
+                                        .param("tableName", tableName)
+                                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                        .andExpect(MockMvcResultMatchers.status().isOk())
+                        .andDo(MockMvcResultHandlers.print())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        R<Void> r = ObjectMapperUtils.fromJSON(responseString, new TypeReference<R<Void>>() {});
+        assertEquals(200, r.getCode());
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Since the listTables interface does not return column-related information, the front-end currently cannot obtain column details. If column information is returned in the listTables interface, the front-end cannot refresh the data when switching tables, so an interface to obtain column information is added here.

### Tests

TableControllerTest#testListColumns

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
