### PR TITLE
[Improvement] Unify java doc of tests in server module via {@link} annotation

### DIFF
--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/CatalogControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/CatalogControllerTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-/** Test for CatalogController. */
+/** Test for {@link CatalogController}. */
 @SpringBootTest
 @AutoConfigureMockMvc
 public class CatalogControllerTest extends ControllerTestBase {

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/CdcJobDefinitionControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/CdcJobDefinitionControllerTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** Test for CdcJobDefinitionController . */
+/** Test for {@link CdcJobDefinitionController} . */
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/DatabaseControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/DatabaseControllerTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-/** Test for DatabaseController. */
+/** Test for {@link DatabaseController}. */
 @SpringBootTest
 @AutoConfigureMockMvc
 public class DatabaseControllerTest extends ControllerTestBase {

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SysMenuControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SysMenuControllerTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Test for SysMenuController. */
+/** Test for {@link SysMenuController}. */
 @SpringBootTest
 @AutoConfigureMockMvc
 public class SysMenuControllerTest extends ControllerTestBase {

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SysRoleControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SysRoleControllerTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Test for SysRoleController. */
+/** Test for {@link SysRoleController}. */
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/TableControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/TableControllerTest.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** Test for TableController. */
+/** Test for {@link TableController}. */
 public class TableControllerTest extends ControllerTestBase {
 
     private static final String catalogPath = "/api/catalog";


### PR DESCRIPTION
### Purpose

The java doc of tests in server module should be unified with {@link} to represent the class which the test is veriied for.

- Before：

```
/** Test for CatalogController. */
@SpringBootTest
@AutoConfigureMockMvc
public class CatalogControllerTest extends ControllerTestBase {
...
}
```

- After:

```
/** Test for {@link CatalogController}. */
@SpringBootTest
@AutoConfigureMockMvc
public class CatalogControllerTest extends ControllerTestBase {
...
}
```

### Tests

- `CatalogControllerTest`
- `CdcJobDefinitionControllerTest`
- `DatabaseControllerTest`
- `SysMenuControllerTest`
- `SysRoleControllerTest`
- `TableControllerTest`

### API and Format

No.

### Documentation

No.