### PR TITLE
[Bugfix] Fix request path of list catalogs interface

### DIFF
--- a/paimon-web-ui-new/mock/modules/metadata.js
+++ b/paimon-web-ui-new/mock/modules/metadata.js
@@ -16,7 +16,7 @@ specific language governing permissions and limitations
 under the License. */
 
 module.exports = (mockUtil) => ({
-  '/catalog/getAllCatalogs': mockUtil({
+  '/catalog/list': mockUtil({
     code: 200,
     msg: 'Successfully',
     'data|5': [

--- a/paimon-web-ui-new/src/api/models/catalog/index.ts
+++ b/paimon-web-ui-new/src/api/models/catalog/index.ts
@@ -44,7 +44,7 @@ export * from './types'
  * # Get all catalog
  */
 export const getAllCatalogs = () => {
-  return httpRequest.get<unknown, ResponseOptions<Catalog[]>>('/catalog/getAllCatalogs')
+  return httpRequest.get<unknown, ResponseOptions<Catalog[]>>('/catalog/list')
 }
 
 /**


### PR DESCRIPTION
### Purpose

close: #157 

API `/catalog/getAllCatalogs` no longer exists since [#99](https://github.com/apache/incubator-paimon-webui/pull/99/files#diff-af0684c9eb5b74942099db6a17667ba11365f3ecd1ced37eca4cb6fceef026d1R71) change it to `/catalog/list`


