### PR TITLE
[Bugfix] Fix swapped OSS_ACCESS_KEY and OSS_SECRET_KEY

### DIFF
--- a/paimon-web-api/src/main/java/org/apache/paimon/web/api/catalog/PaimonServiceFactory.java
+++ b/paimon-web-api/src/main/java/org/apache/paimon/web/api/catalog/PaimonServiceFactory.java
@@ -46,8 +46,8 @@ public class PaimonServiceFactory {
             options.set(CatalogProperties.S3_SECRET_KEY, catalogOptions.get("secretKey"));
         } else if ("oss".equalsIgnoreCase(fileSystemType)) {
             options.set(CatalogProperties.OSS_ENDPOINT, catalogOptions.get("endpoint"));
-            options.set(CatalogProperties.OSS_ACCESS_KEY, catalogOptions.get("accessKey"));
-            options.set(CatalogProperties.OSS_SECRET_KEY, catalogOptions.get("secretKey"));
+            options.set(CatalogProperties.OSS_ACCESS_KEY_ID, catalogOptions.get("accessKey"));
+            options.set(CatalogProperties.OSS_ACCESS_KEY_SECRET, catalogOptions.get("secretKey"));
         }
         CatalogContext context = CatalogContext.create(options);
         return new PaimonService(CatalogFactory.createCatalog(context), name);

--- a/paimon-web-api/src/main/java/org/apache/paimon/web/api/common/CatalogProperties.java
+++ b/paimon-web-api/src/main/java/org/apache/paimon/web/api/common/CatalogProperties.java
@@ -35,9 +35,9 @@ public class CatalogProperties {
 
     public static final String OSS_ENDPOINT = "fs.oss.endpoint";
 
-    public static final String OSS_ACCESS_KEY = "fs.oss.accessKeyId";
+    public static final String OSS_ACCESS_KEY_ID = "fs.oss.accessKeyId";
 
-    public static final String OSS_SECRET_KEY = "fs.oss.accessKeySecret";
+    public static final String OSS_ACCESS_KEY_SECRET = "fs.oss.accessKeySecret";
 
     public static final String HIVE_CONF_DIR = "hive-conf-dir";
 }

--- a/paimon-web-api/src/main/java/org/apache/paimon/web/api/common/CatalogProperties.java
+++ b/paimon-web-api/src/main/java/org/apache/paimon/web/api/common/CatalogProperties.java
@@ -35,9 +35,9 @@ public class CatalogProperties {
 
     public static final String OSS_ENDPOINT = "fs.oss.endpoint";
 
-    public static final String OSS_SECRET_KEY = "fs.oss.accessKeyId";
+    public static final String OSS_ACCESS_KEY = "fs.oss.accessKeyId";
 
-    public static final String OSS_ACCESS_KEY = "fs.oss.accessKeySecret";
+    public static final String OSS_SECRET_KEY = "fs.oss.accessKeySecret";
 
     public static final String HIVE_CONF_DIR = "hive-conf-dir";
 }


### PR DESCRIPTION
### Purpose

Close: #164 

The value of `OSS_ACCESS_KEY` and `OSS_SECRET_KEY` are reversed.
