### PR TITLE
[Fix] Update .gitignore file to reflect module renamed to paimon-web-ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,6 @@ target/
 .vim
 .tmp
 node/
-paimon-manager-ui/.vscode
-paimon-manager-ui/.idea
-paimon-manager-ui/node/*
-paimon-manager-ui/dist/*
-paimon-manager-ui/**/*.proxy.js
 logs/*
 .mvn/
 .www
@@ -53,6 +48,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+node
 .DS_Store
 dist
 dist-ssr
@@ -72,7 +68,7 @@ coverage
 *.sln
 *.sw?
 
-# paimon-web-ui-new
-paimon-web-ui-new/auto-imports.d.ts
-paimon-web-ui-new/httpData
-paimon-web-ui-new/apiWeb.json
+# paimon-web-ui
+paimon-web-ui/auto-imports.d.ts
+paimon-web-ui/httpData
+paimon-web-ui/apiWeb.json


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

close: https://github.com/apache/incubator-paimon-webui/issues/172

The name of the module was changed from paimon-web-ui-new to paimon-web-ui, but the related entries in the .gitignore file have not been updated to reflect this change. This can cause files and directories to be tracked by Git that should be ignored when expected.

Items that need to be updated include but are not limited to:

- paimon-web-ui-new/auto-imports.d.ts
- paimon-web-ui-new/httpData
- paimon-web-ui-new/apiWeb.json