### PR TITLE
[Feature] Add metadata page dragging menu tree width function

### DIFF
--- a/paimon-web-ui/src/views/metadata/index.module.scss
+++ b/paimon-web-ui/src/views/metadata/index.module.scss
@@ -20,6 +20,25 @@ under the License. */
   width: 100%;
   height: 100%;
 
+  .splitter {
+    position: relative;
+    width: 0;
+    height: 100%;
+    flex: none;
+    cursor: col-resize;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: -5px;
+      bottom: 0;
+      left: -5px;
+      background: transparent;
+      z-index: 1;
+    }
+  }
+
   .content {
     display: flex;
     flex-direction: column;

--- a/paimon-web-ui/src/views/metadata/index.tsx
+++ b/paimon-web-ui/src/views/metadata/index.tsx
@@ -28,15 +28,61 @@ export default defineComponent({
     const catalogStore = useCatalogStore()
     const catalogStoreRef = storeToRefs(catalogStore)
 
+    const menuTreeWidth = ref('20%')
+    const isResizing = ref(false)
+
+    const startMenuTreeResize = (event: MouseEvent) => {
+      isResizing.value = true
+      event.preventDefault()
+    }
+
+    const doMenuTreeResize = (event: MouseEvent) => {
+      if (isResizing.value) {
+        const parentWidth = document.documentElement.clientWidth
+        let newWidth = event.clientX
+
+        let widthInPercent = (newWidth / parentWidth) * 100
+
+        widthInPercent = Math.max(15, Math.min(widthInPercent, 40))
+
+        menuTreeWidth.value = `${widthInPercent}%`
+      }
+    }
+
+    const stopMenuTreeResize = () => {
+      isResizing.value = false
+    }
+
+    const contentAreaStyle = computed(() => {
+      const menuWidthPercent = parseFloat(menuTreeWidth.value)
+      return {
+        width: `calc(100% - ${menuWidthPercent}%)`
+      }
+    })
+
+    onMounted(() => {
+      document.addEventListener('mousemove', doMenuTreeResize)
+      document.addEventListener('mouseup', stopMenuTreeResize)
+    })
+
+    onBeforeUnmount(() => {
+      document.removeEventListener('mousemove', doMenuTreeResize)
+      document.removeEventListener('mouseup', stopMenuTreeResize)
+    })
+
     return {
-      currentTable: catalogStoreRef.currentTable
+      currentTable: catalogStoreRef.currentTable,
+      menuTreeWidth,
+      startMenuTreeResize,
+      contentAreaStyle
     }
   },
   render() {
     return (
       <div class={styles.container}>
-        <MenuTree />
-        <div class={styles.content}>
+        <MenuTree style={{ width: this.menuTreeWidth }} />
+        <div class={styles.splitter} onMousedown={this.startMenuTreeResize}></div>
+        <div class={styles.content} style={this.contentAreaStyle}>
           {this.currentTable ? (
             <>
               <Breadcrumb />


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

close: https://github.com/apache/incubator-paimon-webui/issues/180

Add metadata page dragging menu tree width function, enables the user to drag the menu tree size.

before (can't change size):
![image](https://github.com/apache/incubator-paimon-webui/assets/34889415/33b2d8c2-2c8b-49ee-8d29-ddcbf95cf7a6)

after (can be dragged to change size):
![image](https://github.com/apache/incubator-paimon-webui/assets/34889415/6a5b9abf-964b-4f95-8a01-72622e4c1a02)

maximum width：
![image](https://github.com/apache/incubator-paimon-webui/assets/34889415/8b6d6dac-19c2-40c6-9dff-0669349c0c9c)

minimum width：
![image](https://github.com/apache/incubator-paimon-webui/assets/34889415/97d35bb4-73e5-471d-b0ef-297f8f3cf4ff)
